### PR TITLE
fix the resize function to actually zero the buffer as advertised

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,9 @@ impl CryptoVec {
                 if self.capacity > 0 {
                     std::ptr::copy_nonoverlapping(old_ptr, self.p, self.size);
                     munlock(old_ptr, self.size);
+                    for i in 0..self.size {
+                        std::ptr::write_volatile(self.p.offset(i as isize), 0)
+                    }
                     free(old_ptr as *mut c_void);
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,6 @@ impl CryptoVec {
             self.size = size
         } else if size <= self.size {
             // If this is a truncation, resize and erase the extra memory.
-            self.size = size;
             unsafe {
                 libc::memset(
                     self.p.offset(size as isize) as *mut c_void,
@@ -215,6 +214,7 @@ impl CryptoVec {
                     self.size - size,
                 );
             }
+            self.size = size;
         } else {
             // realloc ! and erase the previous memory.
             unsafe {


### PR DESCRIPTION
The resize function did not guarantee an overwrite of the underlying buffer in either of the cases where it should have.

Fix the issues and add unit tests to check these invariants.